### PR TITLE
Updates README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ export default Ember.Component.extend(VelocityMixin, {
 ```javascript
 import VelocityMixin from 'ember-velocity-mixin/main';
 
-export default Ember.Component.extend({
+export default Ember.Component.extend(VelocityMixin, {
   actions: {
     collapse: function() {
       var _this = this;


### PR DESCRIPTION
The mixin was imported in the example, but was not mixed into the component.